### PR TITLE
using jruby friendly syntax for class variable declaration

### DIFF
--- a/lib/connector.rb
+++ b/lib/connector.rb
@@ -24,8 +24,8 @@ module Gauge
     GAUGE_PORT_ENV = "GAUGE_INTERNAL_PORT"
     API_PORT_ENV = "GAUGE_API_PORT"
     HOST_NAME = 'localhost'
-    @@executionSocket
-    @@apiSocket
+    @@executionSocket = nil
+    @@apiSocket = nil
 
     def self.apiSocket
       @@apiSocket


### PR DESCRIPTION
Using plugin version 0.1.0 with jruby-1.7.5:

```
[vagrant@localhost gauge_spike]$ gauge --check specs/
[INFO] NameError: uninitialized class variable @@executionSocket in Gauge::Connector
         Connector at /home/vagrant/.rvm/gems/jruby-1.7.15/gems/gauge-ruby-0.1.0/lib/connector.rb:27
             Gauge at /home/vagrant/.rvm/gems/jruby-1.7.15/gems/gauge-ruby-0.1.0/lib/connector.rb:23
            (root) at /home/vagrant/.rvm/gems/jruby-1.7.15/gems/gauge-ruby-0.1.0/lib/connector.rb:21
           require at org/jruby/RubyKernel.java:1065
            (root) at /home/vagrant/.rvm/rubies/jruby-1.7.15/lib/ruby/shared/rubygems/core_ext/kernel_require.rb:1
           require at /home/vagrant/.rvm/rubies/jruby-1.7.15/lib/ruby/shared/rubygems/core_ext/kernel_require.rb:55
  require_relative at file:/home/vagrant/.rvm/rubies/jruby-1.7.15/lib/jruby.jar!/jruby/kernel19/kernel.rb:24
           require at org/jruby/RubyKernel.java:1065
            (root) at /home/vagrant/.rvm/gems/jruby-1.7.15/gems/gauge-ruby-0.1.0/lib/gauge.rb:18
            (root) at /home/vagrant/.rvm/rubies/jruby-1.7.15/lib/ruby/shared/rubygems/core_ext/kernel_require.rb:1
           require at /home/vagrant/.rvm/rubies/jruby-1.7.15/lib/ruby/shared/rubygems/core_ext/kernel_require.rb:55
           require at org/jruby/RubyKernel.java:1065
  require_relative at file:/home/vagrant/.rvm/rubies/jruby-1.7.15/lib/jruby.jar!/jruby/kernel19/kernel.rb:24
            (root) at /home/vagrant/.rvm/gems/jruby-1.7.15/gems/gauge-ruby-0.1.0/lib/executor.rb:18
            (root) at /home/vagrant/.rvm/rubies/jruby-1.7.15/lib/ruby/shared/rubygems/core_ext/kernel_require.rb:1
           require at org/jruby/RubyKernel.java:1065
           require at /home/vagrant/.rvm/rubies/jruby-1.7.15/lib/ruby/shared/rubygems/core_ext/kernel_require.rb:55
            (root) at -e:1

[INFO] Failed to start Gauge Ruby runner. exit status 1

[CRITICAL] Failed to start gauge API: Runner exited with error: exit status 1

```

Running rake spec fails in similar way
```
[vagrant@localhost gauge-ruby]$ rake -f RakeFile spec
/home/vagrant/.rvm/rubies/jruby-1.7.15/bin/jruby -I/home/vagrant/.rvm/gems/jruby-1.7.15/gems/rspec-support-3.3.0/lib:/home/vagrant/.rvm/gems/jruby-1.7.15/gems/rspec-core-3.3.1/lib /home/vagrant/.rvm/gems/jruby-1.7.15/gems/rspec-core-3.3.1/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb
NameError: uninitialized class variable @@executionSocket in Gauge::Connector
         Connector at /home/vagrant/gauge-ruby/lib/connector.rb:27
             Gauge at /home/vagrant/gauge-ruby/lib/connector.rb:23
            (root) at /home/vagrant/gauge-ruby/lib/connector.rb:21
           require at org/jruby/RubyKernel.java:1065
           require at /home/vagrant/.rvm/rubies/jruby-1.7.15/lib/ruby/shared/rubygems/core_ext/kernel_require.rb:55
           require at /home/vagrant/.rvm/rubies/jruby-1.7.15/lib/ruby/shared/rubygems/core_ext/kernel_require.rb:53
            (root) at file:/home/vagrant/.rvm/rubies/jruby-1.7.15/lib/jruby.jar!/jruby/kernel19/kernel.rb:1
  require_relative at file:/home/vagrant/.rvm/rubies/jruby-1.7.15/lib/jruby.jar!/jruby/kernel19/kernel.rb:24
           require at org/jruby/RubyKernel.java:1065
           require at /home/vagrant/.rvm/rubies/jruby-1.7.15/lib/ruby/shared/rubygems/core_ext/kernel_require.rb:55
           require at /home/vagrant/.rvm/rubies/jruby-1.7.15/lib/ruby/shared/rubygems/core_ext/kernel_require.rb:53
            (root) at /home/vagrant/gauge-ruby/lib/gauge.rb:18
            (root) at file:/home/vagrant/.rvm/rubies/jruby-1.7.15/lib/jruby.jar!/jruby/kernel19/kernel.rb:1
              load at org/jruby/RubyKernel.java:1081
  require_relative at file:/home/vagrant/.rvm/rubies/jruby-1.7.15/lib/jruby.jar!/jruby/kernel19/kernel.rb:24
              each at org/jruby/RubyArray.java:1613
            (root) at /home/vagrant/gauge-ruby/spec/code_parser_spec.rb:20
            (root) at /home/vagrant/.rvm/gems/jruby-1.7.15/gems/rspec-core-3.3.1/lib/rspec/core/configuration.rb:1
   load_spec_files at /home/vagrant/.rvm/gems/jruby-1.7.15/gems/rspec-core-3.3.1/lib/rspec/core/configuration.rb:1327
   load_spec_files at /home/vagrant/.rvm/gems/jruby-1.7.15/gems/rspec-core-3.3.1/lib/rspec/core/configuration.rb:1325
             setup at /home/vagrant/.rvm/gems/jruby-1.7.15/gems/rspec-core-3.3.1/lib/rspec/core/runner.rb:102
            (root) at /home/vagrant/.rvm/gems/jruby-1.7.15/gems/rspec-core-3.3.1/exe/rspec:4
/home/vagrant/.rvm/rubies/jruby-1.7.15/bin/jruby -I/home/vagrant/.rvm/gems/jruby-1.7.15/gems/rspec-support-3.3.0/lib:/home/vagrant/.rvm/gems/jruby-1.7.15/gems/rspec-core-3.3.1/lib /home/vagrant/.rvm/gems/jruby-1.7.15/gems/rspec-core-3.3.1/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb failed
```
