### PR TITLE
Write screenshot to file

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -90,9 +90,8 @@ jobs:
 
       - name: Run tests
         run: |
-          git clone --depth=1 https://github.com/getgauge/gauge-tests
+          git clone --branch=fileBasedScreenshot https://github.com/getgauge/gauge-tests #Remove brach after fileBasedScreenshot branch merge with master
           cd gauge-tests
-          git checkout fileBasedScreenshot #Remove this line after fileBasedScreenshot branch merge with master
           gauge install
           gauge -v
           ./gradlew clean rubyFT

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -88,9 +88,16 @@ jobs:
           go run ./make.go
           go run ./make.go --install
 
+      - name: Install html report
+        run: |
+          git clone --depth=1 https://github.com/getgauge/html-report
+          cd html-report
+          go run build/make.go
+          go run build/make.go --install
+
       - name: Run tests
         run: |
-          git clone --branch=fileBasedScreenshot https://github.com/getgauge/gauge-tests #Remove brach after fileBasedScreenshot branch merge with master
+          git clone --depth=1 --branch=fileBasedScreenshot https://github.com/getgauge/gauge-tests
           cd gauge-tests
           gauge install
           gauge -v

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -92,6 +92,7 @@ jobs:
         run: |
           git clone --depth=1 https://github.com/getgauge/gauge-tests
           cd gauge-tests
+          git checkout fileBasedScreenshot #Remove this line after fileBasedScreenshot branch merge with master
           gauge install
           gauge -v
           ./gradlew clean rubyFT

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Install gauge
         if: matrix.os != 'windows-latest'
         run: |
-          git clone --depth=1 https://github.com/getgauge/gauge.git
+          git clone --depth=1 --branch=write-screenshot-to-file https://github.com/getgauge/gauge.git
           cd gauge
           go run build/make.go --verbose
           go run build/make.go --install --prefix=/tmp/
@@ -73,7 +73,7 @@ jobs:
       - name: Install gauge
         if: matrix.os == 'windows-latest'
         run: |
-          git clone --depth=1 https://github.com/getgauge/gauge.git
+          git clone --depth=1 --branch=write-screenshot-to-file https://github.com/getgauge/gauge.git
           cd gauge
           go run build/make.go --verbose
           go run build/make.go --install

--- a/Rakefile
+++ b/Rakefile
@@ -65,7 +65,7 @@ end
 
 desc "Generate protobuf stubs"
 task :gen_proto do
-    system "grpc_tools_ruby_protoc -I gauge-proto --ruby_out=lib --grpc_out=lib  gauge-proto/*.proto"
+    system "grpc_tools_ruby_protoc -I gauge-proto --ruby_out=lib --grpc_out=lib  gauge-proto/messages.proto gauge-proto/spec.proto gauge-proto/runner.proto"
 end
 
 def create_package(os=nil, arch=nil)

--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -55,11 +55,9 @@ module Gauge
       @includes=[]
       @custom_screengrabber=false
       @screengrabber = -> {
-        file_name = "#{Dir.tmpdir}/screenshot.png"
+        file_name = Util.unique_screenshot_file
         `gauge_screenshot #{file_name}`
-        file_content = File.binread(file_name)
-        File.delete file_name
-        return file_content
+        return File.basename(file_name)
       }
     end
 

--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -80,6 +80,7 @@ module Gauge
     end
 
     def screengrabber=(block)
+      GaugeLog.warning("[DEPRECATED] Use file_based_screengrabber instead.")
       @custom_screengrabber=true
       @screengrabber=block
     end

--- a/lib/configuration.rb
+++ b/lib/configuration.rb
@@ -61,7 +61,7 @@ module Gauge
       }
     end
 
-    attr_reader :custom_screengrabber
+    attr_reader :custom_screengrabber, :file_based_screengrabber
 
     def self.instance
       @configuration ||= Configuration.new
@@ -82,6 +82,16 @@ module Gauge
     def screengrabber=(block)
       @custom_screengrabber=true
       @screengrabber=block
+    end
+
+    def file_based_screengrabber=(block)
+      @custom_screengrabber=true
+      @file_based_screengrabber=true
+      @screengrabber=block
+    end
+
+    def screenshot_dir
+      ENV['screenshots_dir']
     end
 
     def self.include_configured_modules

--- a/lib/gauge_screenshot.rb
+++ b/lib/gauge_screenshot.rb
@@ -32,13 +32,17 @@ module Gauge
     end      
 
     def capture
-      content = Configuration.instance.screengrabber.call
-      if Configuration.instance.custom_screengrabber
+      @screenshots.push(capture_to_file)
+    end
+
+    def capture_to_file
+      if Configuration.instance.custom_screengrabber && !Configuration.instance.file_based_screengrabber
+        content = Configuration.instance.screengrabber.call
         file_name = Util.unique_screenshot_file
         File.write(file_name, content)
-        content = File.basename(file_name)
+        return File.basename(file_name)
       end
-      @screenshots.push(content)
+      Configuration.instance.screengrabber.call
     end
 
     def pending_screenshot

--- a/lib/gauge_screenshot.rb
+++ b/lib/gauge_screenshot.rb
@@ -14,7 +14,7 @@
 
 # You should have received a copy of the GNU General Public License
 # along with Gauge-Ruby.  If not, see <http://www.gnu.org/licenses/>.
-
+require_relative './util'
 module Gauge
   class << self
     def capture
@@ -32,7 +32,13 @@ module Gauge
     end      
 
     def capture
-      @screenshots.push(Configuration.instance.screengrabber.call)
+      content = Configuration.instance.screengrabber.call
+      if Configuration.instance.custom_screengrabber
+        file_name = Util.unique_screenshot_file
+        File.write(file_name, content)
+        content = File.basename(file_name)
+      end
+      @screenshots.push(content)
     end
 
     def pending_screenshot

--- a/lib/processors/execution_handler.rb
+++ b/lib/processors/execution_handler.rb
@@ -57,10 +57,9 @@ module Gauge
              :errorMessage => exception.message,
              :stackTrace => code_snippet + stacktrace,
              :executionTime => execution_time))
-        screenshot = screenshot_bytes
-        if screenshot 
-          # execution_status_response.executionResult.screenShot = screenshot
-          execution_status_response.executionResult.failureScreenshotFile = screenshot
+        screenshot_file = take_screenshot
+        if screenshot_file 
+          execution_status_response.executionResult.failureScreenshotFile = screenshot_file
         end
         execution_status_response.executionResult.screenshotFiles += Gauge::GaugeScreenshot.instance.pending_screenshot
         execution_status_response.executionResult.message += Gauge::GaugeMessages.instance.pending_messages
@@ -73,10 +72,10 @@ module Gauge
         number.to_s + " | " + line.strip + "\n\n"
       end
 
-      def screenshot_bytes
+      def take_screenshot
         return nil if (ENV['screenshot_on_failure'] || "").downcase == "false" || (which("gauge_screenshot").nil? && !Configuration.instance.custom_screengrabber)
         begin
-          Configuration.instance.screengrabber.call
+          GaugeScreenshot.instance.capture_to_file
         rescue Exception => e
           GaugeLog.error e
           return nil

--- a/lib/processors/execution_handler.rb
+++ b/lib/processors/execution_handler.rb
@@ -34,7 +34,7 @@ module Gauge
 
       def handle_pass(execution_time)
         execution_status_response = Messages::ExecutionStatusResponse.new(:executionResult => Messages::ProtoExecutionResult.new(:failed => false, :executionTime => execution_time))
-        execution_status_response.executionResult.screenshots += Gauge::GaugeScreenshot.instance.pending_screenshot
+        execution_status_response.executionResult.screenshotFiles += Gauge::GaugeScreenshot.instance.pending_screenshot
         execution_status_response.executionResult.message += Gauge::GaugeMessages.instance.pending_messages
         execution_status_response
       end
@@ -59,10 +59,10 @@ module Gauge
              :executionTime => execution_time))
         screenshot = screenshot_bytes
         if screenshot 
-          execution_status_response.executionResult.screenShot = screenshot
-          execution_status_response.executionResult.failureScreenshot = screenshot
+          # execution_status_response.executionResult.screenShot = screenshot
+          execution_status_response.executionResult.failureScreenshotFile = screenshot
         end
-        execution_status_response.executionResult.screenshots += Gauge::GaugeScreenshot.instance.pending_screenshot
+        execution_status_response.executionResult.screenshotFiles += Gauge::GaugeScreenshot.instance.pending_screenshot
         execution_status_response.executionResult.message += Gauge::GaugeMessages.instance.pending_messages
         execution_status_response
       end

--- a/lib/processors/execution_hook_processors.rb
+++ b/lib/processors/execution_hook_processors.rb
@@ -28,60 +28,36 @@ module Gauge
     def process_execution_start_request(request)
       Gauge::MethodCache.clear
       Executor.load_steps(Util.get_step_implementation_dir)
-      response = handle_hooks_execution(MethodCache.get_before_suite_hooks,request.currentExecutionInfo,false)
-      response.executionResult.screenshots += Gauge::GaugeScreenshot.instance.pending_screenshot
-      response.executionResult.message += Gauge::GaugeMessages.instance.pending_messages
-      response
+      handle_hooks_execution(MethodCache.get_before_suite_hooks,request.currentExecutionInfo,false)
     end
 
     def process_execution_end_request(request)
-      response = handle_hooks_execution(MethodCache.get_after_suite_hooks, request.currentExecutionInfo, false)
-      response.executionResult.screenshots += Gauge::GaugeScreenshot.instance.pending_screenshot
-      response.executionResult.message += Gauge::GaugeMessages.instance.pending_messages
-      response
+      handle_hooks_execution(MethodCache.get_after_suite_hooks, request.currentExecutionInfo, false)
     end
 
     def process_spec_execution_start_request(request)
-      response = handle_hooks_execution(MethodCache.get_before_spec_hooks,request.currentExecutionInfo)
-      response.executionResult.screenshots += Gauge::GaugeScreenshot.instance.pending_screenshot
-      response.executionResult.message += Gauge::GaugeMessages.instance.pending_messages
-      response
+      handle_hooks_execution(MethodCache.get_before_spec_hooks,request.currentExecutionInfo)
     end
 
     def process_spec_execution_end_request(request)
-      response = handle_hooks_execution(MethodCache.get_after_spec_hooks,request.currentExecutionInfo)
-      response.executionResult.screenshots += Gauge::GaugeScreenshot.instance.pending_screenshot
-      response.executionResult.message += Gauge::GaugeMessages.instance.pending_messages
-      response
+      handle_hooks_execution(MethodCache.get_after_spec_hooks,request.currentExecutionInfo)
     end
 
     def process_scenario_execution_start_request(request)
-      response = handle_hooks_execution(MethodCache.get_before_scenario_hooks,request.currentExecutionInfo)
-      response.executionResult.screenshots += Gauge::GaugeScreenshot.instance.pending_screenshot
-      response.executionResult.message += Gauge::GaugeMessages.instance.pending_messages
-      response
+      handle_hooks_execution(MethodCache.get_before_scenario_hooks,request.currentExecutionInfo)
     end
 
 
     def process_scenario_execution_end_request(request)
-      response = handle_hooks_execution(MethodCache.get_after_scenario_hooks,request.currentExecutionInfo)
-      response.executionResult.screenshots += Gauge::GaugeScreenshot.instance.pending_screenshot
-      response.executionResult.message += Gauge::GaugeMessages.instance.pending_messages
-      response
+      handle_hooks_execution(MethodCache.get_after_scenario_hooks,request.currentExecutionInfo)
     end
 
     def process_step_execution_start_request(request)
-      response = handle_hooks_execution(MethodCache.get_before_step_hooks,request.currentExecutionInfo)
-      response.executionResult.screenshots += Gauge::GaugeScreenshot.instance.pending_screenshot
-      response.executionResult.message += Gauge::GaugeMessages.instance.pending_messages
-      response
+      handle_hooks_execution(MethodCache.get_before_step_hooks,request.currentExecutionInfo)
     end
 
     def process_step_execution_end_request(request)
-      response = handle_hooks_execution(MethodCache.get_after_step_hooks,request.currentExecutionInfo)
-      response.executionResult.screenshots += Gauge::GaugeScreenshot.instance.pending_screenshot
-      response.executionResult.message += Gauge::GaugeMessages.instance.pending_messages
-      response
+      handle_hooks_execution(MethodCache.get_after_step_hooks,request.currentExecutionInfo)
     end
   end
 end

--- a/lib/spec_pb.rb
+++ b/lib/spec_pb.rb
@@ -20,6 +20,8 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
       repeated :preHookScreenshots, :bytes, 12
       repeated :postHookScreenshots, :bytes, 13
       optional :itemCount, :int64, 14
+      repeated :preHookScreenshotFiles, :string, 15
+      repeated :postHookScreenshotFiles, :string, 16
     end
     add_message "gauge.messages.ProtoItem" do
       optional :itemType, :enum, 1, "gauge.messages.ProtoItem.ItemType"
@@ -62,6 +64,8 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
       repeated :postHookMessage, :string, 18
       repeated :preHookScreenshots, :bytes, 19
       repeated :postHookScreenshots, :bytes, 20
+      repeated :preHookScreenshotFiles, :string, 21
+      repeated :postHookScreenshotFiles, :string, 22
     end
     add_message "gauge.messages.Span" do
       optional :start, :int64, 1
@@ -87,6 +91,8 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
       repeated :postHookMessages, :string, 6
       repeated :preHookScreenshots, :bytes, 7
       repeated :postHookScreenshots, :bytes, 8
+      repeated :preHookScreenshotFiles, :string, 9
+      repeated :postHookScreenshotFiles, :string, 10
     end
     add_message "gauge.messages.ProtoConcept" do
       optional :conceptStep, :message, 1, "gauge.messages.ProtoStep"
@@ -182,6 +188,8 @@ Google::Protobuf::DescriptorPool.generated_pool.build do
       repeated :postHookScreenshots, :bytes, 18
       optional :chunked, :bool, 19
       optional :chunkSize, :int64, 20
+      repeated :preHookScreenshotFiles, :string, 21
+      repeated :postHookScreenshotFiles, :string, 22
     end
     add_message "gauge.messages.ProtoSpecResult" do
       optional :protoSpec, :message, 1, "gauge.messages.ProtoSpec"

--- a/lib/util.rb
+++ b/lib/util.rb
@@ -39,6 +39,10 @@ module Gauge
       def step_value(text)
         text.gsub(/(<.*?>)/, "{}")
       end
+      def unique_screenshot_file
+        base_name = "screenshot-#{Process.pid}-#{(Time.now.to_f*10000).to_i}.png"
+        File.join(ENV['screenshots_dir'],base_name)
+      end
     end
   end
 end

--- a/spec/capture_screenshot_spec.rb
+++ b/spec/capture_screenshot_spec.rb
@@ -14,21 +14,35 @@
 
 # You should have received a copy of the GNU General Public License
 # along with Gauge-Ruby.  If not, see <http://www.gnu.org/licenses/>.
-
 describe Gauge do
+    screenshot_dir = File.expand_path('./tmp_screenshots_dir')
+    before(:all) {
+        Dir.mkdir(screenshot_dir)
+        ENV['screenshots_dir'] = screenshot_dir
+    }
+
+    after(:all) {
+        FileUtils.rm_rf(screenshot_dir)
+        ENV['screenshots_dir'] = nil
+    }
     before(:each) {
-        Gauge.configure { |c|  c.screengrabber = -> { return "foo" }}
+        Gauge.configure { |c|  c.screengrabber = -> { return "screenshotdata" }}
       }
     context 'capture screenshot' do
         it "should have a screenshot" do
+            file = File.join(screenshot_dir, 'screenshot-1.png')
+            allow(Gauge::Util).to receive(:unique_screenshot_file).and_return(file)
             Gauge.capture
-            expect(Gauge::GaugeScreenshot.instance.pending_screenshot).to match_array ["foo"]
+            expect(Gauge::GaugeScreenshot.instance.pending_screenshot).to match_array ["screenshot-1.png"]
+            expect(File.read(file)).to eq("screenshotdata")
         end
     end
     context 'clear screenshot' do
         it "should clear screenshot after collecting them" do
+            file = File.join(screenshot_dir, 'screenshot-2.png')
+            allow(Gauge::Util).to receive(:unique_screenshot_file).and_return(file)
             Gauge.capture
-            expect(Gauge::GaugeScreenshot.instance.pending_screenshot).to match_array ["foo"]
+            expect(Gauge::GaugeScreenshot.instance.pending_screenshot).to match_array ["screenshot-2.png"]
             expect(Gauge::GaugeScreenshot.instance.pending_screenshot).to match_array []
         end
     end

--- a/spec/capture_screenshot_spec.rb
+++ b/spec/capture_screenshot_spec.rb
@@ -46,5 +46,13 @@ describe Gauge do
             expect(Gauge::GaugeScreenshot.instance.pending_screenshot).to match_array []
         end
     end
+
+    context 'capture file based screenshot' do
+        it "should have a screenshot" do
+            Gauge.configure { |c|  c.file_based_screengrabber = -> { return "screenshot-3.png" }}
+            Gauge.capture
+            expect(Gauge::GaugeScreenshot.instance.pending_screenshot).to match_array ["screenshot-3.png"]
+        end
+    end
 end
   

--- a/spec/execution_hook_processors_spec.rb
+++ b/spec/execution_hook_processors_spec.rb
@@ -1,101 +1,111 @@
-describe 'Execute Hook' do
-  context 'before suite' do
-    it 'should add custom message and screenshots from before suite' do
-      input = Gauge::Messages::ExecutionStartingRequest.new(:currentExecutionInfo => nil)
-      Gauge::GaugeMessages.instance.write('before suite')
-      Gauge.configure { |c|  c.screengrabber = -> { return "before_suite" }}
-      Gauge::GaugeScreenshot.instance.capture()
-      response = Gauge::Processors.process_execution_start_request(input)
-      expect(response.executionResult.message).to include 'before suite'
-      expect(response.executionResult.screenshots).to match_array ["before_suite"]
-    end
-  end
-
-  context 'after suite' do
-    it 'should add custom message and screenshots from after suite' do
-      input = Gauge::Messages::ExecutionEndingRequest.new(:currentExecutionInfo => nil)
-      Gauge::GaugeMessages.instance.write('after suite')
-      Gauge.configure { |c|  c.screengrabber = -> { return "after_suite" }}
-      Gauge::GaugeScreenshot.instance.capture()
-      response = Gauge::Processors.process_execution_end_request(input)
-      expect(response.executionResult.message).to include 'after suite'
-      expect(response.executionResult.screenshots).to match_array ["after_suite"]
-    end
-  end
-
-  context 'before spec' do
-    it 'should add custom message and screenshots from before spec' do
-      input = Gauge::Messages::SpecExecutionStartingRequest.new(:currentExecutionInfo => nil)
-      Gauge::GaugeMessages.instance.write('before spec')
-      Gauge.configure { |c|  c.screengrabber = -> { return "before_spec" }}
-      Gauge::GaugeScreenshot.instance.capture()
-      response = Gauge::Processors.process_spec_execution_start_request(input)
-      expect(response.executionResult.message).to include 'before spec'
-      expect(response.executionResult.screenshots).to match_array ["before_spec"]
-    end
-  end
-
-  context 'after spec' do
-    it 'should add custom message and screenshots from after spec' do
-      input = Gauge::Messages::SpecExecutionEndingRequest.new(:currentExecutionInfo => nil)
-      Gauge::GaugeMessages.instance.write('after spec')
-      Gauge.configure { |c|  c.screengrabber = -> { return "after_spec" }}
-      Gauge::GaugeScreenshot.instance.capture()
-      response = Gauge::Processors.process_spec_execution_end_request(input)
-      expect(response.executionResult.message).to include 'after spec'
-      expect(response.executionResult.screenshots).to match_array ["after_spec"]
-    end
-  end
-
-  context 'before scenario' do
-    it 'should add custom message and screenshots from before scenario' do
-      input = Gauge::Messages::ScenarioExecutionStartingRequest.new(:currentExecutionInfo => nil)
-      Gauge::GaugeMessages.instance.write('before scenario')
-      Gauge.configure { |c|  c.screengrabber = -> { return "before_scenario" }}
-      Gauge::GaugeScreenshot.instance.capture()
-      response = Gauge::Processors.process_scenario_execution_start_request(input)
-      expect(response.executionResult.message).to include 'before scenario'
-      expect(response.executionResult.screenshots).to match_array ["before_scenario"]
-    end
-  end
-
-  context 'after scenario' do
-    it 'should add custom message and screenshots from after scenario' do
-      input = Gauge::Messages::ScenarioExecutionEndingRequest.new(:currentExecutionInfo => nil)
-      Gauge::GaugeMessages.instance.write('after scenario')
-      Gauge.configure { |c|  c.screengrabber = -> { return "after_scenario" }}
-      Gauge::GaugeScreenshot.instance.capture()
-      response = Gauge::Processors.process_scenario_execution_end_request(input)
-      expect(response.executionResult.message).to include 'after scenario'
-      expect(response.executionResult.screenshots).to match_array ["after_scenario"]
-    end
-  end
-
-  context 'before step' do
-    it 'should add custom message and screenshots from before step' do
-      input = Gauge::Messages::StepExecutionStartingRequest.new(:currentExecutionInfo => nil)
-      Gauge::GaugeMessages.instance.write('before step')
-      Gauge.configure { |c|  c.screengrabber = -> { return "before_step" }}
-      Gauge::GaugeScreenshot.instance.capture()
-      response = Gauge::Processors.process_step_execution_start_request(input)
-      expect(response.executionResult.message).to include 'before step'
-      expect(response.executionResult.screenshots).to match_array ["before_step"]
-    end
-  end
-
-  context 'after step' do
-    it 'should add custom message and screenshots from after step' do
-      input = Gauge::Messages::StepExecutionEndingRequest.new(:currentExecutionInfo => nil)
-      Gauge::GaugeMessages.instance.write('after step')
-      Gauge.configure { |c|  c.screengrabber = -> { return "after_step" }}
-      Gauge::GaugeScreenshot.instance.capture()
-      response = Gauge::Processors.process_step_execution_end_request(input)
-      expect(response.executionResult.message).to include 'after step'
-      expect(response.executionResult.screenshots).to match_array ["after_step"]
-    end
-  end
-
-  after(:each) {
-    Gauge::GaugeMessages.instance.clear()
+describe "Execute Hook" do
+  screenshot_dir = File.expand_path("./tmp_screenshots_dir")
+  before(:all) {
+    Dir.mkdir(screenshot_dir)
+    ENV["screenshots_dir"] = screenshot_dir
   }
+  before(:each) do |e|
+    screenshot_instance = instance_double("Gauge::GaugeScreenshot")
+    messages_instance = instance_double("Gauge::GaugeMessages")
+    screenshot_klass = class_double("Gauge::GaugeScreenshot").as_stubbed_const
+    messages_klass = class_double("Gauge::GaugeMessages").as_stubbed_const
+
+    expect(screenshot_instance).to receive(:pending_screenshot).and_return(e.metadata[:screenshots_file])
+    expect(screenshot_klass).to receive(:instance).and_return(screenshot_instance)
+
+    expect(messages_instance).to receive(:pending_messages).and_return(e.metadata[:message])
+    expect(messages_klass).to receive(:instance).and_return(messages_instance)
+  end
+
+  after(:all) {
+    FileUtils.rm_rf(screenshot_dir)
+    ENV["screenshots_dir"] = nil
+  }
+  context "before suite" do
+    it "should add custom message and screenshots from before suite", {
+         screenshots_file: ["before-suite.png"], message: ["before suite"],
+       } do
+      input = Gauge::Messages::ExecutionStartingRequest.new(:currentExecutionInfo => nil)
+      response = Gauge::Processors.process_execution_start_request(input)
+      expect(response.executionResult.message).to include "before suite"
+      expect(response.executionResult.screenshotFiles).to match_array ["before-suite.png"]
+    end
+  end
+
+  context "after suite" do
+    it "should add custom message and screenshots from after suite", {
+         screenshots_file: ["after-suite.png"], message: ["after suite"],
+       } do
+      input = Gauge::Messages::ExecutionEndingRequest.new(:currentExecutionInfo => nil)
+      response = Gauge::Processors.process_execution_end_request(input)
+      expect(response.executionResult.message).to include "after suite"
+      expect(response.executionResult.screenshotFiles).to match_array ["after-suite.png"]
+    end
+  end
+
+  context "before spec" do
+    it "should add custom message and screenshots from before spec", {
+      screenshots_file: ["before-spec.png"], message: ["before spec"],
+    } do
+      input = Gauge::Messages::SpecExecutionStartingRequest.new(:currentExecutionInfo => nil)
+      response = Gauge::Processors.process_spec_execution_start_request(input)
+      expect(response.executionResult.message).to include "before spec"
+      expect(response.executionResult.screenshotFiles).to match_array ["before-spec.png"]
+    end
+  end
+
+  context "after spec" do
+    it "should add custom message and screenshots from after spec", {
+      screenshots_file: ["after-spec.png"], message: ["after spec"],
+    } do
+      input = Gauge::Messages::SpecExecutionEndingRequest.new(:currentExecutionInfo => nil)
+      response = Gauge::Processors.process_spec_execution_end_request(input)
+      expect(response.executionResult.message).to include "after spec"
+      expect(response.executionResult.screenshotFiles).to match_array ["after-spec.png"]
+    end
+  end
+
+  context "before scenario" do
+    it "should add custom message and screenshots from before scenario", {
+      screenshots_file: ["before-scenario.png"], message: ["before scenario"],
+    } do
+      input = Gauge::Messages::ScenarioExecutionStartingRequest.new(:currentExecutionInfo => nil)
+      response = Gauge::Processors.process_scenario_execution_start_request(input)
+      expect(response.executionResult.message).to include "before scenario"
+      expect(response.executionResult.screenshotFiles).to match_array ["before-scenario.png"]
+    end
+  end
+
+  context "after scenario" do
+    it "should add custom message and screenshots from after scenario", {
+      screenshots_file: ["after-scenario.png"], message: ["after scenario"],
+    } do
+      input = Gauge::Messages::ScenarioExecutionEndingRequest.new(:currentExecutionInfo => nil)
+      response = Gauge::Processors.process_scenario_execution_end_request(input)
+      expect(response.executionResult.message).to include "after scenario"
+      expect(response.executionResult.screenshotFiles).to match_array ["after-scenario.png"]
+    end
+  end
+
+  context "before step" do
+    it "should add custom message and screenshots from before step", {
+      screenshots_file: ["before-step.png"], message: ["before step"],
+    } do
+      input = Gauge::Messages::StepExecutionStartingRequest.new(:currentExecutionInfo => nil)
+      response = Gauge::Processors.process_step_execution_start_request(input)
+      expect(response.executionResult.message).to include "before step"
+      expect(response.executionResult.screenshotFiles).to match_array ["before-step.png"]
+    end
+  end
+
+  context "after step" do
+    it "should add custom message and screenshots from after step", {
+      screenshots_file: ["after-step.png"], message: ["after step"],
+    } do
+      input = Gauge::Messages::StepExecutionEndingRequest.new(:currentExecutionInfo => nil)
+      response = Gauge::Processors.process_step_execution_end_request(input)
+      expect(response.executionResult.message).to include "after step"
+      expect(response.executionResult.screenshotFiles).to match_array ["after-step.png"]
+    end
+  end
 end


### PR DESCRIPTION
- [x] Changed default screenshot grabber to write to file and return file path.
- [x] Depricate existing custom screenshot grabber API contract.
- [x] Create a new API contact for custom screenshot grabber to write the screenshot into file and returning file path instead of screenhsot bytes.

```
Gauge.configure do |config|
  config.file_based_screengrabber = -> {
    screenshot_data = driver.screenshot_as(:png)
    file = File.join(config.screenshot_dir, 'screenshot-name.png')
    File.write(file, screenshot_data)
    File.basename(file)
  }
end
```