### PR TITLE
Use gauge-lsp-tests action from it's repo

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Install bundler
         run: |
-          gem install bundler:2.0.2
+          gem install bundler:2.1.4
 
       - name: Run tests
         run: |
@@ -80,7 +80,7 @@ jobs:
 
       - name: Install bundler
         run: |
-          gem install bundler:2.0.2
+          gem install bundler:2.1.4
 
       - name: Install gauge ruby
         run: |
@@ -139,11 +139,11 @@ jobs:
       - uses: getgauge/setup-gauge@master
         with:
           gauge-version: release
-          plugins: screenshot,html-report,js
+          plugins: screenshot,html-report, js
 
       - name: Install bundler
         run: |
-          gem install bundler:2.0.2
+          gem install bundler:2.1.4
 
       - name: Install gauge ruby
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -75,7 +75,7 @@ jobs:
 
       - uses: getgauge/setup-gauge@master
         with:
-          gauge-version: release 
+          gauge-version: master
           gauge-plugins: screenshot,html-report,java
 
       - name: Install bundler
@@ -138,7 +138,7 @@ jobs:
 
       - uses: getgauge/setup-gauge@master
         with:
-          gauge-version: release
+          gauge-version: master 
           gauge-plugins: screenshot,html-report, js
 
       - name: Install bundler

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -150,21 +150,6 @@ jobs:
           go run ./make.go
           go run ./make.go --install
 
-      - name: Prepare lsp tests
-        run: |
-          git clone --depth=1 https://github.com/getgauge/gauge-lsp-tests
-          cd gauge-lsp-tests
-          npm install
-          gauge install
-
-      - name: Run lsp tests
-        run: |
-          cd gauge-lsp-tests
-          gauge -v
-          gauge run  --tags='!knownIssue & (actions_on_project_load | actions_on_file_edit)' --env=ruby-wd
-
-      - uses: actions/upload-artifact@master
-        if: failure()
+      - uses: getgauge/gauge-lsp-tests@githubaction
         with:
-          name: lsp-logs-${{ matrix.os }}
-          path: gauge-lsp-tests/logs
+          env: ruby-wd

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -150,6 +150,6 @@ jobs:
           go run ./make.go
           go run ./make.go --install
 
-      - uses: getgauge/gauge-lsp-tests@githubaction
+      - uses: getgauge/run-lsp-tests@main
         with:
           env: ruby-wd

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -76,7 +76,7 @@ jobs:
       - uses: getgauge/setup-gauge@master
         with:
           gauge-version: release 
-          plugins: screenshot,html-report,java
+          gauge-plugins: screenshot,html-report,java
 
       - name: Install bundler
         run: |
@@ -139,7 +139,7 @@ jobs:
       - uses: getgauge/setup-gauge@master
         with:
           gauge-version: release
-          plugins: screenshot,html-report, js
+          gauge-plugins: screenshot,html-report, js
 
       - name: Install bundler
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,10 +17,10 @@ jobs:
         run: |
           node -e "console.log(JSON.stringify(process.env, null, '  '))"
 
-      - name: Set up Ruby 2.7.x
+      - name: Set up Ruby 2.6.x
         uses: actions/setup-ruby@v1
         with:
-          ruby-version: 2.7.x
+          ruby-version: 2.6.x
 
       - name: Install bundler
         run: |
@@ -58,10 +58,10 @@ jobs:
           echo "RUBY_PLUGIN_BRANCH=$COMMIT_HASH" >> $GITHUB_ENV
           echo "LOCAL_RUBY_PLUGIN_PATH=$(pwd)" >> $GITHUB_ENV
 
-      - name: Set up Ruby 2.7.x
+      - name: Set up Ruby 2.6.x
         uses: actions/setup-ruby@v1
         with:
-          ruby-version: 2.7.x
+          ruby-version: 2.6.x
 
       - name: Setup go 1.13.1
         uses: actions/setup-go@v1
@@ -126,10 +126,10 @@ jobs:
           echo "RUBY_PLUGIN_BRANCH=$COMMIT_HASH" >> $GITHUB_ENV
           echo "LOCAL_RUBY_PLUGIN_PATH=$(pwd)" >> $GITHUB_ENV
 
-      - name: Set up Ruby 2.7.x
+      - name: Set up Ruby 2.6.x
         uses: actions/setup-ruby@v1
         with:
-          ruby-version: 2.7.x
+          ruby-version: 2.6.x
 
       - name: Setup go 1.13.1
         uses: actions/setup-go@v1

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -24,7 +24,7 @@ jobs:
 
       - name: Install bundler
         run: |
-          gem install bundler:2.1.4
+          gem install bundler:2.0.2
 
       - name: Run tests
         run: |
@@ -80,7 +80,7 @@ jobs:
 
       - name: Install bundler
         run: |
-          gem install bundler:2.1.4
+          gem install bundler:2.0.2
 
       - name: Install gauge ruby
         run: |
@@ -143,7 +143,7 @@ jobs:
 
       - name: Install bundler
         run: |
-          gem install bundler:2.1.4
+          gem install bundler:2.0.2
 
       - name: Install gauge ruby
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,10 +17,10 @@ jobs:
         run: |
           node -e "console.log(JSON.stringify(process.env, null, '  '))"
 
-      - name: Set up Ruby 2.6.x
+      - name: Set up Ruby 2.7.x
         uses: actions/setup-ruby@v1
         with:
-          ruby-version: 2.6.x
+          ruby-version: 2.7.x
 
       - name: Install bundler
         run: |
@@ -58,10 +58,10 @@ jobs:
           echo "RUBY_PLUGIN_BRANCH=$COMMIT_HASH" >> $GITHUB_ENV
           echo "LOCAL_RUBY_PLUGIN_PATH=$(pwd)" >> $GITHUB_ENV
 
-      - name: Set up Ruby 2.6.x
+      - name: Set up Ruby 2.7.x
         uses: actions/setup-ruby@v1
         with:
-          ruby-version: 2.6.x
+          ruby-version: 2.7.x
 
       - name: Setup go 1.13.1
         uses: actions/setup-go@v1
@@ -75,7 +75,8 @@ jobs:
 
       - uses: getgauge/setup-gauge@master
         with:
-          gauge-version: master
+          gauge-version: release 
+          plugins: screenshot,html-report,java
 
       - name: Install bundler
         run: |
@@ -90,8 +91,6 @@ jobs:
         run: |
           git clone --depth=1 https://github.com/getgauge/gauge-tests
           cd gauge-tests
-          gauge install
-          gauge -v
           ./gradlew clean rubyFT
 
       - uses: actions/upload-artifact@master
@@ -127,10 +126,10 @@ jobs:
           echo "RUBY_PLUGIN_BRANCH=$COMMIT_HASH" >> $GITHUB_ENV
           echo "LOCAL_RUBY_PLUGIN_PATH=$(pwd)" >> $GITHUB_ENV
 
-      - name: Set up Ruby 2.6.x
+      - name: Set up Ruby 2.7.x
         uses: actions/setup-ruby@v1
         with:
-          ruby-version: 2.6.x
+          ruby-version: 2.7.x
 
       - name: Setup go 1.13.1
         uses: actions/setup-go@v1
@@ -139,7 +138,8 @@ jobs:
 
       - uses: getgauge/setup-gauge@master
         with:
-          gauge-version: master
+          gauge-version: release
+          plugins: screenshot,html-report,js
 
       - name: Install bundler
         run: |


### PR DESCRIPTION
Move executing lsp actions to the gauge-lsp-tests repo for re-use

Signed-off-by: Zabil Cheriya Maliackal <zabilcm@gmail.com>