### PR TITLE
Drop EOL Ruby 3.0 support

### DIFF
--- a/.github/workflows/release-on-pr-merge.yml
+++ b/.github/workflows/release-on-pr-merge.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 3.2
+          ruby-version: 3.3
 
       - name: Setup git
         run: |

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        ruby_version: ['3.0', '3.1', '3.2', '3.3']
+        ruby_version: ['3.1', '3.2', '3.3']
       fail-fast: false
 
     steps:
@@ -42,7 +42,7 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, ubuntu-latest]
-        ruby_version: ['3.0', '3.1', '3.2', '3.3']
+        ruby_version: ['3.1', '3.2', '3.3']
       fail-fast: false
 
     steps:
@@ -111,7 +111,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest]
-        ruby_version: ['3.0', '3.1', '3.2', '3.3']
+        ruby_version: ['3.1', '3.2', '3.3']
       fail-fast: false
 
     steps:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,10 +1,10 @@
 PATH
   remote: .
   specs:
-    gauge-ruby (0.8.0)
+    gauge-ruby (0.9.0)
       grpc (~> 1.10, >= 1.10.0)
-      parser (>= 3.0, < 4.0)
-      unparser (>= 0.5.0, < 0.7.0)
+      parser (>= 3.1, < 4.0)
+      unparser (>= 0.6.4, < 0.7.0)
 
 GEM
   remote: https://rubygems.org/
@@ -62,7 +62,7 @@ GEM
       simplecov_json_formatter (~> 0.1)
     simplecov-html (0.12.3)
     simplecov_json_formatter (0.1.4)
-    unparser (0.6.13)
+    unparser (0.6.15)
       diff-lcs (~> 1.3)
       parser (>= 3.3.0)
     yard (0.9.36)
@@ -86,4 +86,4 @@ DEPENDENCIES
   yard
 
 BUNDLED WITH
-   2.5.6
+   2.5.13

--- a/gauge-ruby.gemspec
+++ b/gauge-ruby.gemspec
@@ -18,9 +18,9 @@ Gem::Specification.new do |s|
     s.homepage    = "https://gauge.org"
     s.files = Dir.glob("lib/**/*.rb")
 
-    s.add_runtime_dependency 'parser', '>= 3.0', '< 4.0'
-    s.add_runtime_dependency 'unparser', '>= 0.5.0', '< 0.7.0'
+    s.add_runtime_dependency 'parser', '>= 3.1', '< 4.0'
+    s.add_runtime_dependency 'unparser', '>= 0.6.4', '< 0.7.0'
     s.add_runtime_dependency 'grpc', '~> 1.10', '>= 1.10.0'
     s.add_development_dependency 'grpc-tools', '~> 1.10', '>= 1.10.0'
-    s.required_ruby_version = ">= 3.0"
+    s.required_ruby_version = ">= 3.1"
 end

--- a/ruby.json
+++ b/ruby.json
@@ -1,6 +1,6 @@
 {
     "id" : "ruby",
-    "version" : "0.8.0",
+    "version" : "0.9.0",
 	"description": "ruby support for gauge",
     "install": {
         "windows": [],


### PR DESCRIPTION
Tests have been running against Ruby 3.3 for some time and Ruby 3.0 has been EOL for a month now, so we can drop support and move forward.

https://endoflife.date/ruby