### PR TITLE
Correct compatibility for gauge-ruby gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     gauge-ruby (0.9.1)
       google-protobuf (>= 3, < 4)
-      grpc (~> 1.10, >= 1.10.0)
+      grpc (~> 1.10, >= 1.10.0, < 1.65)
       parser (>= 3.1, < 4.0)
       unparser (>= 0.6.4, < 0.7.0)
 
@@ -77,7 +77,7 @@ PLATFORMS
 
 DEPENDENCIES
   gauge-ruby!
-  grpc-tools (~> 1.10, >= 1.10.0)
+  grpc-tools (~> 1.10, >= 1.10.0, < 1.65)
   method_source
   os
   rake

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,8 @@
 PATH
   remote: .
   specs:
-    gauge-ruby (0.9.0)
+    gauge-ruby (0.9.1)
+      google-protobuf (>= 3, < 4)
       grpc (~> 1.10, >= 1.10.0)
       parser (>= 3.1, < 4.0)
       unparser (>= 0.6.4, < 0.7.0)
@@ -37,7 +38,7 @@ GEM
     grpc-tools (1.64.0)
     method_source (1.1.0)
     os (1.1.4)
-    parser (3.3.3.0)
+    parser (3.3.4.0)
       ast (~> 2.4.1)
       racc
     racc (1.8.0)

--- a/gauge-ruby.gemspec
+++ b/gauge-ruby.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |s|
     s.add_runtime_dependency 'parser', '>= 3.1', '< 4.0'
     s.add_runtime_dependency 'unparser', '>= 0.6.4', '< 0.7.0'
     s.add_runtime_dependency 'grpc', '~> 1.10', '>= 1.10.0'
+    s.add_runtime_dependency 'google-protobuf', '>= 3', '< 4'
     s.add_development_dependency 'grpc-tools', '~> 1.10', '>= 1.10.0'
     s.required_ruby_version = ">= 3.1"
 end

--- a/gauge-ruby.gemspec
+++ b/gauge-ruby.gemspec
@@ -20,8 +20,8 @@ Gem::Specification.new do |s|
 
     s.add_runtime_dependency 'parser', '>= 3.1', '< 4.0'
     s.add_runtime_dependency 'unparser', '>= 0.6.4', '< 0.7.0'
-    s.add_runtime_dependency 'grpc', '~> 1.10', '>= 1.10.0'
+    s.add_runtime_dependency 'grpc', '~> 1.10', '>= 1.10.0', '< 1.65'
     s.add_runtime_dependency 'google-protobuf', '>= 3', '< 4'
-    s.add_development_dependency 'grpc-tools', '~> 1.10', '>= 1.10.0'
+    s.add_development_dependency 'grpc-tools', '~> 1.10', '>= 1.10.0', '< 1.65'
     s.required_ruby_version = ">= 3.1"
 end

--- a/ruby.json
+++ b/ruby.json
@@ -1,6 +1,6 @@
 {
     "id" : "ruby",
-    "version" : "0.9.0",
+    "version" : "0.9.1",
 	"description": "ruby support for gauge",
     "install": {
         "windows": [],


### PR DESCRIPTION
gauge-ruby is not currently compatible with google-protobuf 4 as it has a direct dependency with a breaking change. Will release a patch release that corrects the constraints to avoid people's dependabots breaking things.

Also works around an independent grpc problem with `1.65.0` that is breaking the integration tests due to polluted stdout/stderr (but may not be an issue at runtime): https://github.com/grpc/grpc/issues/37178